### PR TITLE
Fix filter logic to respect dataset attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
       <input type="checkbox" class="filter" data-filter="rule_type" value="guidance" checked>
       Green
     </label>
-    <label>
   </section>
 
   <main id="content">

--- a/script.js
+++ b/script.js
@@ -59,9 +59,10 @@ function applyFilters() {
       sec.style.display = "";
       return;
     }
-    const visible = Object.entries(checks).every(
-      ([k, set]) => set.has(sec.dataset[k])
-    );
+    const visible = Object.entries(checks).every(([k, set]) => {
+      const key = k.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+      return set.has(sec.dataset[key]);
+    });
     sec.style.display = visible ? "" : "none";
   });
 }


### PR DESCRIPTION
## Summary
- handle underscore-delimited filter keys by converting to camelCase
- clean filters markup in `index.html`

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894861418d48332b2a1c6269f8b7e25