### PR TITLE
Fix rule type highlighting and default visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,7 +55,7 @@ function applyFilters() {
     }, {});
 
   document.querySelectorAll("#content > section").forEach(sec => {
-    if (sec.dataset.ruleType === "always_show") {
+    if (sec.dataset.ruleType === "always_show" || sec.dataset.ruleType === "general_info") {
       sec.style.display = "";
       return;
     }

--- a/style.css
+++ b/style.css
@@ -71,31 +71,31 @@ section.clause {
 }
 
 /* Light Blue – statutory */
-[data-ruleType="statutory"] {
+[data-rule-type="statutory"] {
     background-color: rgba(173, 216, 230, 0.25);
     border-left-color: #00aaff;
 }
 
 /* Magenta (shown as red) – code_of_practice */
-[data-ruleType="code_of_practice"] {
+[data-rule-type="code_of_practice"] {
     background-color: rgba(255, 0, 128, 0.15);
     border-left-color: #ff0080;
 }
 
 /* Green – guidance */
-[data-ruleType="guidance"] {
+[data-rule-type="guidance"] {
     background-color: rgba(0, 128, 0, 0.12);
     border-left-color: #008000;
 }
 
 /* Blue/Grey – general_info */
-[data-ruleType="general_info"] {
+[data-rule-type="general_info"] {
     background-color: rgba(70, 130, 180, 0.12);
     border-left-color: #4682b4;
 }
 
 /* Yellow – always_show */
-[data-ruleType="always_show"] {
+[data-rule-type="always_show"] {
     background-color: rgba(255, 255, 0, 0.2);
     border-left-color: #cccc00;
 }


### PR DESCRIPTION
## Summary
- use `data-rule-type` CSS selectors so tag highlights render
- keep `general_info` sections visible regardless of filter options

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68948666088483329f583fcc5015341b