### PR TITLE
Fix clause highlight CSS specificity

### DIFF
--- a/style.css
+++ b/style.css
@@ -71,31 +71,31 @@ section.clause {
 }
 
 /* Light Blue – statutory */
-[data-rule-type="statutory"] {
+section.clause[data-rule-type="statutory"] {
     background-color: rgba(173, 216, 230, 0.25);
     border-left-color: #00aaff;
 }
 
 /* Magenta (shown as red) – code_of_practice */
-[data-rule-type="code_of_practice"] {
+section.clause[data-rule-type="code_of_practice"] {
     background-color: rgba(255, 0, 128, 0.15);
     border-left-color: #ff0080;
 }
 
 /* Green – guidance */
-[data-rule-type="guidance"] {
+section.clause[data-rule-type="guidance"] {
     background-color: rgba(0, 128, 0, 0.12);
     border-left-color: #008000;
 }
 
 /* Blue/Grey – general_info */
-[data-rule-type="general_info"] {
+section.clause[data-rule-type="general_info"] {
     background-color: rgba(70, 130, 180, 0.12);
     border-left-color: #4682b4;
 }
 
 /* Yellow – always_show */
-[data-rule-type="always_show"] {
+section.clause[data-rule-type="always_show"] {
     background-color: rgba(255, 255, 0, 0.2);
     border-left-color: #cccc00;
 }


### PR DESCRIPTION
## Summary
- ensure rule-type highlights appear by increasing CSS selector specificity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68949ebcb544833287a22c44d5d654d4