### PR TITLE
Pin filter bar to top during scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -47,10 +47,15 @@ blockquote {
 
 /* Filter Controls */
 .filters {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: #f9f9f9;
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
     margin-bottom: 1.5rem;
+    padding: 0.5rem 0;
 }
 .filters label {
     background: #ddd;


### PR DESCRIPTION
## Summary
- Keep the filter selection bar visible while scrolling by making it sticky at the top of the page

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894a1b2a5ac8332bbea02b0902e81f2