### PR TITLE
Decouple blueGrey visibility from UI toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,6 @@
       <input type="checkbox" class="filter" data-filter="rule_type" value="guidance" checked>
       Green
     </label>
-      <label><input type="checkbox" class="filter" data-filter="rule_type" value="general_info" checked> 
-       Blue / Grey
-    </label>
   </section>
 
   <main id="content">


### PR DESCRIPTION
## Summary
- Normalize `blueGrey` and `alwaysShow` tags to `general_info`
- Ensure sections without corresponding filter controls remain visible
- Remove obsolete Blue/Grey filter from index.html

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689526a885cc8332afd8bbf72e811d0e