### PR TITLE
feat: redesign layout with dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,23 +6,34 @@
   <title>NPO Handbook Viewer</title>
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
+<body data-theme="light">
   <header class="main-header">
     <h1><span class="logo" aria-hidden="true">📘</span> NPO Handbook Viewer</h1>
   </header>
 
+  <section class="theme-switcher">
+    <label class="toggle">
+      <input type="checkbox" id="theme-toggle">
+      <span class="toggle-track"></span>
+      <span class="toggle-label">Dark mode</span>
+    </label>
+  </section>
+
   <section class="filters">
-    <label>
+    <label class="toggle">
       <input type="checkbox" class="filter" data-filter="rule_type" value="statutory" checked>
-      Light Blue
+      <span class="toggle-track"></span>
+      <span class="toggle-label">Light Blue</span>
     </label>
-    <label>
+    <label class="toggle">
       <input type="checkbox" class="filter" data-filter="rule_type" value="code_of_practice" checked>
-      Magenta
+      <span class="toggle-track"></span>
+      <span class="toggle-label">Magenta</span>
     </label>
-    <label>
+    <label class="toggle">
       <input type="checkbox" class="filter" data-filter="rule_type" value="guidance" checked>
-      Green
+      <span class="toggle-track"></span>
+      <span class="toggle-label">Green</span>
     </label>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -11,6 +11,13 @@ const RULE_TYPE_ALIASES = {
 };
 
 function init() {
+  const themeToggle = document.getElementById("theme-toggle");
+  if (themeToggle) {
+    themeToggle.addEventListener("change", e => {
+      document.body.dataset.theme = e.target.checked ? "dark" : "light";
+    });
+  }
+
   fetch("policy.md")
     .then(r => r.text())
     .then(render)

--- a/style.css
+++ b/style.css
@@ -1,159 +1,248 @@
-/* General layout */
+/* Theme variables */
+:root {
+  --color-bg: #f5f7fa;
+  --color-text: #1a1d1f;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f0f2f5;
+  --color-accent: #0d6efd;
+  --color-border: rgba(0, 0, 0, 0.06);
+  --color-muted: #6b7280;
+
+  --stat: #0a84ff;
+  --cop: #ff1a8d;
+  --guidance: #22c55e;
+  --general: #4682b4;
+  --always: #e3b341;
+
+  --stat-bg: rgba(10, 132, 255, 0.1);
+  --cop-bg: rgba(255, 26, 141, 0.1);
+  --guidance-bg: rgba(34, 197, 94, 0.1);
+  --general-bg: rgba(70, 130, 180, 0.1);
+  --always-bg: rgba(227, 179, 65, 0.15);
+}
+
+[data-theme="dark"] {
+  --color-bg: #1c1f24;
+  --color-text: #e5e7eb;
+  --color-surface: #24282f;
+  --color-surface-muted: #2d333b;
+  --color-accent: #3b82f6;
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-muted: #9ca3af;
+
+  --stat-bg: rgba(10, 132, 255, 0.2);
+  --cop-bg: rgba(255, 26, 141, 0.2);
+  --guidance-bg: rgba(34, 197, 94, 0.2);
+  --general-bg: rgba(70, 130, 180, 0.2);
+  --always-bg: rgba(227, 179, 65, 0.25);
+}
+
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    line-height: 1.6;
-    max-width: 1000px;
-    margin: 2rem auto;
-    padding: 0 1rem;
-    background-color: #f9f9f9;
-    color: #222;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  line-height: 1.6;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 1rem 4rem;
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 
 /* Header */
 header.main-header {
-    text-align: center;
-    background: linear-gradient(135deg, #1e90ff, #7b68ee);
-    color: #fff;
-    padding: 2rem 1rem;
-    margin-bottom: 2rem;
-    border-radius: 0 0 10px 10px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: 2rem 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid var(--color-border);
+  border-radius: 0 0 10px 10px;
 }
 
 header.main-header h1 {
-    margin: 0;
-    border-bottom: none;
-    padding: 0;
-    font-size: 2rem;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 0.5rem;
+  margin: 0;
+  font-size: 2.25rem;
+  font-weight: 600;
+  line-height: 1.2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 header.main-header .logo {
-    font-size: 2.5rem;
+  font-size: 2.5rem;
 }
 
-/* Headings */
+/* Utility bar */
+.theme-switcher {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+/* Toggle switches */
+.toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background: var(--color-surface-muted);
+  border-radius: 1rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.9rem;
+}
+
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.toggle-track {
+  width: 2.25rem;
+  height: 1.25rem;
+  background: var(--color-border);
+  border-radius: 1rem;
+  position: relative;
+  transition: background 0.3s;
+  flex-shrink: 0;
+}
+
+.toggle-track::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1rem;
+  height: 1rem;
+  background: var(--color-surface);
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s;
+}
+
+.toggle input:checked + .toggle-track {
+  background: var(--color-accent);
+}
+
+.toggle input:checked + .toggle-track::after {
+  transform: translateX(1rem);
+}
+
+.toggle-label {
+  color: var(--color-text);
+}
+
+/* Filters container */
+.filters {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-surface);
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+/* Typography */
 h1, h2, h3, h4 {
-    margin-top: 2rem;
-    border-bottom: 1px solid #ddd;
-    padding-bottom: 0.25em;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.25;
+  font-weight: 600;
+  color: var(--color-text);
 }
 
 /* Tables */
 table {
-    border-collapse: collapse;
-    width: 100%;
-    margin: 1.5em 0;
-    background: #fff;
-}
-th, td {
-    border: 1px solid #aaa;
-    padding: 0.5em;
-    text-align: left;
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1.5em 0;
+  background: var(--color-surface);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
-/* Markdown HR */
+th, td {
+  border: 1px solid var(--color-border);
+  padding: 0.5em;
+  text-align: left;
+}
+
+/* Horizontal rule */
 hr {
-    border: none;
-    border-top: 1px dashed #aaa;
-    margin: 2rem 0;
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 2rem 0;
 }
 
 /* Blockquotes */
 blockquote {
-    border-left: 5px solid #ccc;
-    padding-left: 1em;
-    background: #f4f4f4;
-    margin: 1em 0;
-    color: #555;
+  border-left: 4px solid var(--color-border);
+  padding-left: 1em;
+  background: var(--color-surface-muted);
+  margin: 1em 0;
+  color: var(--color-muted);
 }
 
-/* Filter Controls */
-.filters {
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    background: #f9f9f9;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-bottom: 1.5rem;
-    padding: 0.5rem 0;
-}
-.filters label {
-    display: flex;
-    align-items: center;
-    background: #fff;
-    border: 1px solid #ccc;
-    padding: 0.3rem 0.75rem;
-    border-radius: 20px;
-    cursor: pointer;
-    transition: background 0.3s, transform 0.2s;
-}
-.filters label:hover {
-    background: #eee;
-    transform: translateY(-2px);
-}
-.filters input[type="checkbox"] {
-    margin-right: 0.3rem;
-    accent-color: #1e90ff;
-}
-
-/* Clause block highlights by ruleType */
+/* Clause block highlights */
 section.clause {
-    padding: 1em;
-    margin: 1em 0;
-    border-left: 5px solid transparent;
-    background-color: #fff;
+  padding: 1rem 1.25rem;
+  margin: 1rem 0;
+  border-left: 4px solid transparent;
+  background: var(--color-surface);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  border-radius: 0.5rem;
 }
 
-/* Light Blue – statutory */
 section.clause[data-rule-type="statutory"] {
-    background-color: rgba(173, 216, 230, 0.25);
-    border-left-color: #00aaff;
+  border-left-color: var(--stat);
+  background: var(--stat-bg);
 }
 
-/* Magenta (shown as red) – code_of_practice */
 section.clause[data-rule-type="code_of_practice"] {
-    background-color: rgba(255, 0, 128, 0.15);
-    border-left-color: #ff0080;
+  border-left-color: var(--cop);
+  background: var(--cop-bg);
 }
 
-/* Green – guidance */
 section.clause[data-rule-type="guidance"] {
-    background-color: rgba(0, 128, 0, 0.12);
-    border-left-color: #008000;
+  border-left-color: var(--guidance);
+  background: var(--guidance-bg);
 }
 
-/* Blue/Grey – general_info */
 section.clause[data-rule-type="general_info"] {
-    background-color: rgba(70, 130, 180, 0.12);
-    border-left-color: #4682b4;
+  border-left-color: var(--general);
+  background: var(--general-bg);
 }
 
-/* Yellow – always_show */
 section.clause[data-rule-type="always_show"] {
-    background-color: rgba(255, 255, 0, 0.2);
-    border-left-color: #cccc00;
+  border-left-color: var(--always);
+  background: var(--always-bg);
 }
 
 /* Definition highlighting */
 .def-term {
-    border-bottom: 1px dotted #666;
-    cursor: help;
+  border-bottom: 1px dotted var(--color-muted);
+  cursor: help;
 }
 
 .definition-tooltip {
-    position: absolute;
-    background: #fff;
-    border: 1px solid #ccc;
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
-    max-width: 250px;
-    display: none;
-    z-index: 1000;
+  position: absolute;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  max-width: 250px;
+  display: none;
+  z-index: 1000;
+  color: var(--color-text);
 }
+


### PR DESCRIPTION
## Summary
- restyle layout with layered surfaces and clearer typography
- add dark mode toggle and custom toggle controls
- support dark theme variables for clause styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952a3f3d988332bb72e9522a9335b4