### PR TITLE
Color filter toggles by rule type

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,17 +20,17 @@
   </section>
 
   <section class="filters">
-    <label class="toggle">
+    <label class="toggle toggle-statutory">
       <input type="checkbox" class="filter" data-filter="rule_type" value="statutory" checked>
       <span class="toggle-track"></span>
       <span class="toggle-label">Statutory Requirements (Light Blue)</span>
     </label>
-    <label class="toggle">
+    <label class="toggle toggle-code">
       <input type="checkbox" class="filter" data-filter="rule_type" value="code_of_practice" checked>
       <span class="toggle-track"></span>
       <span class="toggle-label">NPO Codes of Practice (Red)</span>
     </label>
-    <label class="toggle">
+    <label class="toggle toggle-guidance">
       <input type="checkbox" class="filter" data-filter="rule_type" value="guidance" checked>
       <span class="toggle-track"></span>
       <span class="toggle-label">Guidance Notes (Green)</span>

--- a/style.css
+++ b/style.css
@@ -131,6 +131,23 @@ header.main-header .logo {
 
 .toggle input:checked + .toggle-track::after {
   transform: translateX(1rem);
+  background: var(--color-accent);
+}
+
+/* Rule type-specific toggle colours */
+.toggle-statutory input:checked + .toggle-track,
+.toggle-statutory input:checked + .toggle-track::after {
+  background: var(--stat);
+}
+
+.toggle-code input:checked + .toggle-track,
+.toggle-code input:checked + .toggle-track::after {
+  background: var(--cop);
+}
+
+.toggle-guidance input:checked + .toggle-track,
+.toggle-guidance input:checked + .toggle-track::after {
+  background: var(--guidance);
 }
 
 .toggle-label {


### PR DESCRIPTION
## Summary
- Add per-rule classes to filter toggles
- Style toggle track and knob using rule type colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895bf4b1b608332a5b7cedce2febd55